### PR TITLE
Add community projects

### DIFF
--- a/data/projects/ansible-collection.yaml
+++ b/data/projects/ansible-collection.yaml
@@ -5,4 +5,4 @@ description: >-
 author: NetBird
 category: Tools
 url: https://github.com/netbirdio/ansible-netbird
-badge: official
+badge: endorsed

--- a/data/projects/ansible-netbird.yaml
+++ b/data/projects/ansible-netbird.yaml
@@ -1,0 +1,7 @@
+name: ansible-netbird
+description: >-
+  An Ansible collection for deploying and managing NetBird servers and peers, with dynamic
+  inventory for peer data.
+author: Dominion Solutions
+category: Tools
+url: https://github.com/dominion-solutions/ansible-netbird

--- a/data/projects/docker-netbird.yaml
+++ b/data/projects/docker-netbird.yaml
@@ -1,0 +1,7 @@
+name: docker-netbird
+description: >-
+  A rootless, distroless Docker image that packages the NetBird management server, dashboard,
+  and signal server into one lightweight container.
+author: 11notes
+category: Apps
+url: https://github.com/11notes/docker-netbird

--- a/data/projects/jetbird.yaml
+++ b/data/projects/jetbird.yaml
@@ -5,4 +5,4 @@ description: >-
 author: bg443
 category: Apps
 url: https://codeberg.org/bg443/JetBird
-badge: endorsed
+

--- a/data/projects/jetbird.yaml
+++ b/data/projects/jetbird.yaml
@@ -1,0 +1,8 @@
+name: JetBird
+description: >-
+  An unofficial, privacy-focused native Android client for NetBird, adding split tunneling,
+  per-app exclusion, and Rosenpass support. Available on F-Droid.
+author: bg443
+category: Apps
+url: https://codeberg.org/bg443/JetBird
+badge: endorsed

--- a/data/projects/mavlink-anywhere.yaml
+++ b/data/projects/mavlink-anywhere.yaml
@@ -1,0 +1,7 @@
+name: mavlink-anywhere
+description: >-
+  A companion-computer routing dashboard for drone MAVLink telemetry that uses NetBird for
+  secure remote access to ground stations and operators.
+author: alireza787b
+category: Apps
+url: https://github.com/alireza787b/mavlink-anywhere

--- a/data/projects/nanonetbird.yaml
+++ b/data/projects/nanonetbird.yaml
@@ -1,0 +1,7 @@
+name: nanoNetBird
+description: >-
+  Brings the NetBird client to nanoKVM out-of-band management devices, with a single-command
+  install that auto-updates.
+author: bc547
+category: Apps
+url: https://github.com/bc547/nanoNetBird

--- a/data/projects/netbird-api-exporter.yaml
+++ b/data/projects/netbird-api-exporter.yaml
@@ -1,0 +1,9 @@
+name: NetBird API Exporter
+description: >-
+  Prometheus exporter that collects metrics from the NetBird API (peers, groups,
+  users, networks, and DNS) and exposes them for monitoring, with a prebuilt
+  Grafana dashboard.
+author: Matan Baruch
+category: Extensions
+url: https://github.com/matanbaruch/netbird-api-exporter
+badge: endorsed

--- a/data/projects/netbird-aur.yaml
+++ b/data/projects/netbird-aur.yaml
@@ -1,0 +1,7 @@
+name: NetBird on Arch (AUR)
+description: >-
+  AUR package that builds and installs the NetBird client from source on Arch
+  Linux, with a prebuilt netbird-bin variant also available.
+author: tarball
+category: Apps
+url: https://aur.archlinux.org/packages/netbird

--- a/data/projects/netbird-connect.yaml
+++ b/data/projects/netbird-connect.yaml
@@ -5,3 +5,4 @@ description: >-
 author: Alemiz112
 category: Extensions
 url: https://github.com/Alemiz112/netbird-connect
+badge: endorsed

--- a/data/projects/netbird-connect.yaml
+++ b/data/projects/netbird-connect.yaml
@@ -1,0 +1,7 @@
+name: netbird-connect
+description: >-
+  A GitHub Action that joins your CI/CD runners to a NetBird network so workflows can reach
+  private resources securely.
+author: Alemiz112
+category: Extensions
+url: https://github.com/Alemiz112/netbird-connect

--- a/data/projects/netbird-delayed-auto-update-windows.yaml
+++ b/data/projects/netbird-delayed-auto-update-windows.yaml
@@ -1,0 +1,7 @@
+name: netbird-delayed-auto-update-windows
+description: >-
+  A PowerShell script and scheduled task that delays NetBird Windows client updates by a set
+  number of days to avoid rolling out bad releases.
+author: NetHorror
+category: Tools
+url: https://github.com/NetHorror/netbird-delayed-auto-update-windows

--- a/data/projects/netbird-exporter.yaml
+++ b/data/projects/netbird-exporter.yaml
@@ -1,0 +1,7 @@
+name: netbird-exporter
+description: >-
+  A Prometheus exporter that surfaces NetBird peer connection status, latency, and traffic
+  metrics for your dashboards.
+author: gocloudio
+category: Interfaces
+url: https://github.com/gocloudio/netbird-exporter

--- a/data/projects/netbird-for-openwrt.yaml
+++ b/data/projects/netbird-for-openwrt.yaml
@@ -5,4 +5,4 @@ description: >-
 author: NetBird
 category: Extensions
 url: https://github.com/netbirdio/openwrt-netbird
-badge: official
+badge: endorsed

--- a/data/projects/netbird-for-talos.yaml
+++ b/data/projects/netbird-for-talos.yaml
@@ -1,0 +1,8 @@
+name: NetBird for Talos Linux
+description: >-
+  Talos Linux system extension that runs the NetBird client on Talos nodes,
+  giving machines on your NetBird network secure access to your Talos
+  Kubernetes nodes.
+author: Sidero Labs
+category: Extensions
+url: https://github.com/siderolabs/extensions/tree/main/network/netbird

--- a/data/projects/netbird-helm-chart.yaml
+++ b/data/projects/netbird-helm-chart.yaml
@@ -1,0 +1,9 @@
+name: NetBird Helm Chart
+description: >-
+  Official Helm chart for deploying NetBird's self-hosted control plane
+  (management, signal, relay, and dashboard) into a Kubernetes cluster, with
+  ingress, persistence, and monitoring support.
+author: NetBird
+category: Apps
+url: https://github.com/netbirdio/helms/tree/main/charts/netbird
+badge: official

--- a/data/projects/netbird-management-cli.yaml
+++ b/data/projects/netbird-management-cli.yaml
@@ -1,8 +1,0 @@
-name: netbird-management-cli
-description: >-
-  An unofficial Go CLI to manage NetBird peers, groups, policies, and DNS from the terminal
-  via the REST API.
-author: TechHutTV
-category: Interfaces
-url: https://github.com/TechHutTV/netbird-management-cli
-badge: endorsed

--- a/data/projects/netbird-mullvad-bypass.yaml
+++ b/data/projects/netbird-mullvad-bypass.yaml
@@ -1,0 +1,7 @@
+name: netbird-mullvad-bypass
+description: >-
+  An nftables-based bypass that lets NetBird and Mullvad VPN coexist on Linux, with packages
+  for Arch, Fedora/RHEL, and Debian/Ubuntu.
+author: d10n
+category: Tools
+url: https://github.com/d10n/netbird-mullvad-bypass

--- a/data/projects/netbird-nixos.yaml
+++ b/data/projects/netbird-nixos.yaml
@@ -1,0 +1,8 @@
+name: NetBird for NixOS
+description: >-
+  NetBird client package and services.netbird module in nixpkgs for
+  declaratively installing and configuring the NetBird client on NixOS.
+author: nixpkgs maintainers
+category: Apps
+url: https://github.com/NixOS/nixpkgs/tree/master/pkgs/by-name/ne/netbird
+badge: endorsed

--- a/data/projects/netbird-proxmox-lxc.yaml
+++ b/data/projects/netbird-proxmox-lxc.yaml
@@ -1,0 +1,9 @@
+name: NetBird Proxmox LXC
+description: >-
+  Community helper script that creates a Proxmox VE LXC container running the
+  NetBird client, set up as a routing peer to bridge your Proxmox network into
+  your NetBird network.
+author: Community Scripts
+category: Apps
+url: https://community-scripts.org/scripts/add-netbird-lxc?id=add-netbird-lxc
+badge: endorsed

--- a/data/projects/netbird-python-client.yaml
+++ b/data/projects/netbird-python-client.yaml
@@ -1,0 +1,7 @@
+name: netbird-python-client
+description: >-
+  An unofficial Python client library for the NetBird API, covering 30+ resources for managing
+  your network as code.
+author: drtinkerer
+category: Tools
+url: https://github.com/drtinkerer/netbird-python-client

--- a/data/projects/netbird-snap.yaml
+++ b/data/projects/netbird-snap.yaml
@@ -1,0 +1,8 @@
+name: NetBird Snap
+description: >-
+  Snap package of the NetBird client for Linux, letting you install and run
+  NetBird on Ubuntu and other snapd-compatible distributions via the Snap Store.
+author: Ubuntu Robotics
+category: Apps
+url: https://github.com/ubuntu-robotics/netbird_snap
+badge: endorsed

--- a/data/projects/netbird-traefik.yaml
+++ b/data/projects/netbird-traefik.yaml
@@ -1,0 +1,7 @@
+name: netbird-traefik
+description: >-
+  Run NetBird behind a Traefik reverse proxy using Traefik labels, without changing your
+  existing stack.
+author: yblis
+category: Extensions
+url: https://github.com/yblis/netbird-traefik

--- a/data/projects/netdesk.yaml
+++ b/data/projects/netdesk.yaml
@@ -1,0 +1,8 @@
+name: NetDesk
+description: >-
+  A Chrome extension that adds one-click RustDesk remote access (desktop, terminal, file
+  transfer) right inside the NetBird dashboard.
+author: yblis
+category: Extensions
+url: https://github.com/yblis/NetDesk
+badge: endorsed

--- a/data/projects/netdesk.yaml
+++ b/data/projects/netdesk.yaml
@@ -5,4 +5,3 @@ description: >-
 author: yblis
 category: Extensions
 url: https://github.com/yblis/NetDesk
-badge: endorsed


### PR DESCRIPTION
## Description

Adds community-built NetBird projects to the directory — the batch that was held back from the initial commit pending curation. Each is a single YAML file under `data/projects/`, validated against `schema/project.schema.json`.

This is a **data-only** change: `README.md` and `dist/projects.json` are intentionally **not** included. They are generated artifacts and will be refreshed automatically by the `Generate` workflow after this merges (it opens a `chore/regenerate` PR with the updated files). This PR doubles as the first live exercise of that automation.

## NetBird projects — full repo (29)

### Official

- [netbirdio/addon-netbird](https://github.com/netbirdio/addon-netbird) — by NetBird
- [netbirdio/helms](https://github.com/netbirdio/helms/tree/main/charts/netbird) — by NetBird
- [netbirdio/kubernetes-operator](https://github.com/netbirdio/kubernetes-operator) — by NetBird
- [netbirdio/netbird-crossplane-provider](https://github.com/netbirdio/netbird-crossplane-provider) — by NetBird
- [netbirdio/netbird-unraid](https://github.com/netbirdio/netbird-unraid) — by NetBird
- [netbirdio/network-manager-vpn-plugin](https://github.com/netbirdio/network-manager-vpn-plugin) — by NetBird
- [netbirdio/pfsense-netbird](https://github.com/netbirdio/pfsense-netbird) — by NetBird
- [netbirdio/terraform-provider-netbird](https://github.com/netbirdio/terraform-provider-netbird) — by NetBird

### Endorsed

- [Alemiz112/netbird-connect](https://github.com/Alemiz112/netbird-connect) — by Alemiz112
- [matanbaruch/netbird-api-exporter](https://github.com/matanbaruch/netbird-api-exporter) — by Matan Baruch
- [NetBird Proxmox LXC](https://community-scripts.org/scripts/add-netbird-lxc?id=add-netbird-lxc) — by Community Scripts
- [netbirdio/ansible-netbird](https://github.com/netbirdio/ansible-netbird) — by NetBird
- [netbirdio/openwrt-netbird](https://github.com/netbirdio/openwrt-netbird) — by NetBird
- [NixOS/nixpkgs](https://github.com/NixOS/nixpkgs/tree/master/pkgs/by-name/ne/netbird) — by nixpkgs maintainers
- [TechHutTV/netbird-management-cli](https://github.com/TechHutTV/netbird-management-cli) — by TechHutTV _(on main, not in this branch)_
- [ubuntu-robotics/netbird_snap](https://github.com/ubuntu-robotics/netbird_snap) — by Ubuntu Robotics

### Community (no badge)

- [11notes/docker-netbird](https://github.com/11notes/docker-netbird) — by 11notes
- [alireza787b/mavlink-anywhere](https://github.com/alireza787b/mavlink-anywhere) — by alireza787b
- [bc547/nanoNetBird](https://github.com/bc547/nanoNetBird) — by bc547
- [d10n/netbird-mullvad-bypass](https://github.com/d10n/netbird-mullvad-bypass) — by d10n
- [dominion-solutions/ansible-netbird](https://github.com/dominion-solutions/ansible-netbird) — by Dominion Solutions
- [drtinkerer/netbird-python-client](https://github.com/drtinkerer/netbird-python-client) — by drtinkerer
- [gocloudio/netbird-exporter](https://github.com/gocloudio/netbird-exporter) — by gocloudio
- [JetBird](https://codeberg.org/bg443/JetBird) — by bg443
- [NetBird on Arch (AUR)](https://aur.archlinux.org/packages/netbird) — by tarball
- [NetHorror/netbird-delayed-auto-update-windows](https://github.com/NetHorror/netbird-delayed-auto-update-windows) — by NetHorror
- [siderolabs/extensions](https://github.com/siderolabs/extensions/tree/main/network/netbird) — by Sidero Labs
- [yblis/netbird-traefik](https://github.com/yblis/netbird-traefik) — by yblis
- [yblis/NetDesk](https://github.com/yblis/NetDesk) — by yblis


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added several new community project listings, expanding the available ecosystem content.
  * New entries include tools, apps, and extensions such as Android clients, Docker images, management utilities, exporters, and routing/integration helpers.
  * Each listing now includes descriptive details like author, category, and project link for easier discovery.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->