### PR TITLE
Add bulk community content (6 entries)

### DIFF
--- a/data/content/45homelab-netbird-vs-tailscale.yaml
+++ b/data/content/45homelab-netbird-vs-tailscale.yaml
@@ -2,4 +2,5 @@ title: "NetBird vs Tailscale: The One I’d Trust With My #homelab"
 type: video
 source: 45HomeLab
 url: https://www.youtube.com/watch?v=jnGsStleHd0
+publish_date: 2026-01-08
 featured: false

--- a/data/content/45homelab-netbird-vs-tailscale.yaml
+++ b/data/content/45homelab-netbird-vs-tailscale.yaml
@@ -1,0 +1,5 @@
+title: "NetBird vs Tailscale: The One I’d Trust With My #homelab"
+type: video
+source: 45HomeLab
+url: https://www.youtube.com/watch?v=jnGsStleHd0
+featured: false

--- a/data/content/cameron-knauff-unattended-remote-desktop-gnome-wayland.yaml
+++ b/data/content/cameron-knauff-unattended-remote-desktop-gnome-wayland.yaml
@@ -1,0 +1,5 @@
+title: "The EASIEST Unattended Remote Desktop for GNOME/Wayland."
+type: video
+source: Cameron Knauff
+url: https://www.youtube.com/watch?v=7ikzAnjk6YM
+featured: false

--- a/data/content/cameron-knauff-unattended-remote-desktop-gnome-wayland.yaml
+++ b/data/content/cameron-knauff-unattended-remote-desktop-gnome-wayland.yaml
@@ -2,4 +2,5 @@ title: "The EASIEST Unattended Remote Desktop for GNOME/Wayland."
 type: video
 source: Cameron Knauff
 url: https://www.youtube.com/watch?v=7ikzAnjk6YM
+publish_date: 2026-06-19
 featured: false

--- a/data/content/devops-toolbox-underrated-tool-homelab.yaml
+++ b/data/content/devops-toolbox-underrated-tool-homelab.yaml
@@ -2,4 +2,5 @@ title: "This Underrated Tool Replaced 3 Homelab Services (and it's open source!)
 type: video
 source: DevOps Toolbox
 url: https://www.youtube.com/watch?v=3wJ0IQ3rHjA
+publish_date: 2026-06-26
 featured: false

--- a/data/content/devops-toolbox-underrated-tool-homelab.yaml
+++ b/data/content/devops-toolbox-underrated-tool-homelab.yaml
@@ -1,0 +1,5 @@
+title: "This Underrated Tool Replaced 3 Homelab Services (and it's open source!)"
+type: video
+source: DevOps Toolbox
+url: https://www.youtube.com/watch?v=3wJ0IQ3rHjA
+featured: false

--- a/data/content/makeuseof-netbird-home-server-router-port.yaml
+++ b/data/content/makeuseof-netbird-home-server-router-port.yaml
@@ -1,0 +1,6 @@
+title: "I was exposing my home server every time I opened a router port — NetBird fixed it"
+type: article
+source: MakeUseOf
+url: https://www.makeuseof.com/was-exposing-home-server-every-time-opened-router-port-netbird-fixed/
+publish_date: 2026-03-21
+featured: false

--- a/data/content/philip-thomas-nas-mini-server-n8n.yaml
+++ b/data/content/philip-thomas-nas-mini-server-n8n.yaml
@@ -2,4 +2,5 @@ title: "NAS als Mini-Server: n8n & KI-Agenten zu Hause laufen lassen (Terramaste
 type: video
 source: Philip Thomas
 url: https://www.youtube.com/watch?v=C26MtK-GVtc
+publish_date: 2026-06-27
 featured: false

--- a/data/content/philip-thomas-nas-mini-server-n8n.yaml
+++ b/data/content/philip-thomas-nas-mini-server-n8n.yaml
@@ -1,0 +1,5 @@
+title: "NAS als Mini-Server: n8n & KI-Agenten zu Hause laufen lassen (Terramaster F4-425 Pro)"
+type: video
+source: Philip Thomas
+url: https://www.youtube.com/watch?v=C26MtK-GVtc
+featured: false

--- a/data/content/techhut-self-hosted-remote-access-home-server.yaml
+++ b/data/content/techhut-self-hosted-remote-access-home-server.yaml
@@ -2,4 +2,5 @@ title: "REAL Self-Hosted Remote Access for YOUR Home Server"
 type: video
 source: TechHut
 url: https://www.youtube.com/watch?v=z0HPuNFkmt4
+publish_date: 2026-03-19
 featured: false

--- a/data/content/techhut-self-hosted-remote-access-home-server.yaml
+++ b/data/content/techhut-self-hosted-remote-access-home-server.yaml
@@ -1,0 +1,5 @@
+title: "REAL Self-Hosted Remote Access for YOUR Home Server"
+type: video
+source: TechHut
+url: https://www.youtube.com/watch?v=z0HPuNFkmt4
+featured: false


### PR DESCRIPTION
## Summary

Adds 6 new community content entries under `data/content/` — one article and five videos covering NetBird (remote access, homelab use, comparisons, and self-hosting walkthroughs).

## New entries

| Title | Type | Source | Publish date |
|---|---|---|---|
| I was exposing my home server every time I opened a router port — NetBird fixed it | article | MakeUseOf | 2026-03-21 |
| REAL Self-Hosted Remote Access for YOUR Home Server | video | TechHut | — |
| NetBird vs Tailscale: The One I’d Trust With My #homelab | video | 45HomeLab | — |
| This Underrated Tool Replaced 3 Homelab Services (and it's open source!) | video | DevOps Toolbox | — |
| The EASIEST Unattended Remote Desktop for GNOME/Wayland. | video | Cameron Knauff | — |
| NAS als Mini-Server: n8n & KI-Agenten zu Hause laufen lassen (Terramaster F4-425 Pro) | video | Philip Thomas | — |
