### PR TITLE
Add caddy-netbird (Extensions, endorsed)

### DIFF
--- a/data/projects/caddy-netbird.yaml
+++ b/data/projects/caddy-netbird.yaml
@@ -1,0 +1,9 @@
+name: caddy-netbird
+description: >-
+  A Caddy plugin that embeds a NetBird client, letting the reverse proxy route
+  HTTP and raw TCP/UDP traffic to upstreams through a NetBird network instead of
+  the public internet.
+author: lixmal
+category: Extensions
+url: https://github.com/lixmal/caddy-netbird
+badge: endorsed


### PR DESCRIPTION
## Summary

Adds [`lixmal/caddy-netbird`](https://github.com/lixmal/caddy-netbird) — a Caddy plugin that embeds a NetBird client, letting the reverse proxy route HTTP and raw TCP/UDP traffic to upstreams through a NetBird network instead of the public internet.

## Entry

| Field | Value |
|---|---|
| Name | caddy-netbird |
| Category | Extensions |
| Badge | endorsed |
| Author | lixmal |
| URL | https://github.com/lixmal/caddy-netbird |


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new project listing with key details such as name, description, author, category, repository link, and status badge.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->