### PR TITLE
Add project: luci-app-netbird

### DIFF
--- a/data/projects/luci-app-netbird.yaml
+++ b/data/projects/luci-app-netbird.yaml
@@ -1,0 +1,7 @@
+name: luci-app-netbird
+description: >-
+  A LuCI web UI for managing the NetBird client on OpenWrt / ImmortalWrt
+  routers, with one-click firewall zone and LAN-to-mesh forwarding setup.
+author: looong-cat
+category: Extensions
+url: https://github.com/looong-cat/luci-app-netbird


### PR DESCRIPTION
Adds luci-app-netbird — a LuCI web UI for managing the NetBird client on OpenWrt / ImmortalWrt routers, with one-click firewall zone and LAN-to-mesh forwarding setup.

Submitting per the invitation from @TechHutTV in https://github.com/looong-cat/luci-app-netbird/issues/2.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new LuCI app entry for NetBird with basic app details and repository information, making it available in the project listings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->