### PR TITLE
Add NetBird Connect Runner

### DIFF
--- a/data/projects/netbird-connect-runner.yaml
+++ b/data/projects/netbird-connect-runner.yaml
@@ -1,0 +1,8 @@
+name: NetBird Connect Runner
+description: >-
+  A GitHub Action that joins a workflow runner to your NetBird network as an
+  ephemeral peer, so CI/CD jobs can reach private resources like internal
+  services, databases, and jump hosts over WireGuard.
+author: shaban00
+category: Extensions
+url: https://github.com/shaban00/netbird-connect


### PR DESCRIPTION
Adds NetBird Connect Runner, a GitHub Action that joins workflow runners to a NetBird network as ephemeral peers.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new project listing for **NetBird Connect Runner**.
  * Included key details such as its description, author, category, and upstream repository link.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->