### PR TITLE
Add NetBird Expose Runner

### DIFF
--- a/data/projects/netbird-expose.yaml
+++ b/data/projects/netbird-expose.yaml
@@ -1,0 +1,9 @@
+name: NetBird Expose Runner
+description: >-
+  A GitHub Action that builds a project's Docker service on the workflow
+  runner and exposes it through the NetBird reverse proxy with automatic TLS
+  and optional auth, holds it live for a configurable duration, then tears
+  down the ephemeral peer.
+author: shaban00
+category: Extensions
+url: https://github.com/shaban00/netbird-expose


### PR DESCRIPTION
Adds NetBird Expose Runner, a GitHub Action that builds a Docker service in CI and exposes it through the NetBird reverse proxy (v0.66+). Companion to NetBird Connect Runner — the runner joins the mesh first, then this action handles build, expose, and teardown.