### PR TITLE
Add project: netbird-tui

### DIFF
--- a/data/projects/netbird-tui.yaml
+++ b/data/projects/netbird-tui.yaml
@@ -1,0 +1,7 @@
+name: netbird-tui
+description: >-
+  A terminal UI for the local NetBird daemon that uses the daemon gRPC socket
+  for keyboard-driven monitoring and management of peers, routes, DNS, and more.
+author: n0pashkov
+category: Interfaces
+url: https://github.com/n0pashkov/netbird-tui


### PR DESCRIPTION
Adds [netbird-tui](https://github.com/n0pashkov/netbird-tui) under Interfaces — a terminal UI for the local NetBird daemon (peers, routes, DNS, diagnostics) via the daemon gRPC socket.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/netbirdio/codesmith/awesome-netbird/pr/15"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786990289&installation_id=146802194&pr_number=15&repository=netbirdio%2Fawesome-netbird&return_to=https%3A%2F%2Fgithub.com%2Fnetbirdio%2Fawesome-netbird%2Fpull%2F15&signature=6cbb811fe5998534ece2ffad722f982164cb2c42c15a314ffbd07fceb19946ad"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added the netbird-tui project to the project directory, including its description, author, category, and repository link.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->