### PR TITLE
Add Nuticast (Xcode wireless debugging over NetBird)

### DIFF
--- a/data/projects/nuticast.yaml
+++ b/data/projects/nuticast.yaml
@@ -1,0 +1,8 @@
+name: Nuticast
+description: >-
+  Mac menu-bar app that keeps Xcode wireless debugging working when an
+  iPhone leaves the local network, by bridging Apple's device discovery
+  over a NetBird network.
+author: webwarrior06
+category: Extensions
+url: https://nuticast.com


### PR DESCRIPTION
Adds Nuticast to the community project directory.

Nuticast reads `netbird status --json` to match an iPhone to its NetBird peer, then bridges Apple's Bonjour/RemotePairing traffic over the existing NetBird network so Xcode can debug the device after it leaves the Mac's LAN. No cloud relay; traffic stays on the user's NetBird network.

Homepage: https://nuticast.com
Setup guide: https://nuticast.com/blog/netbird-for-ios-developers

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Nuticast to the project directory.
  * Listed it under Extensions with a link to its website.
  * Added a description of its Mac menu-bar functionality for maintaining Xcode wireless debugging across networks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->